### PR TITLE
Normalise parameter name when not using split-env.

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,11 @@ const formatParameterName = (name, { splitEnv, upperCase, envPrefix }) => {
   if (splitEnv) {
     const splited = name.split('/');
     formatedName = splited[splited.length-1];
+  } else {
+    if (formatedName.startsWith('/')) {
+      formatedName = formatedName.substring(1);
+    }
+    formatedName = formatedName.replace(/\//g, '_');
   }
   if (upperCase) {
     formatedName = formatedName.toUpperCase();


### PR DESCRIPTION
Removes the first slash if it is at the start of the string and replaces subsequent slashes with _. This better fits shell environment variable naming, and environment variables cannot start with a slash.

So /dev/launch_codes/nukes becomes dev_launch_codes_nukes.